### PR TITLE
Legend endlabel styling

### DIFF
--- a/quicklooks/_cell_linter.py
+++ b/quicklooks/_cell_linter.py
@@ -59,7 +59,7 @@ EXPECTED_PARAMS: dict[str, list[str]] = {
         "linewidth", "linestyle", "marker",
         "opacity", "label", "end_label", "layer_order",
     ],
-    "legend": ["location", "frame"],
+    "legend": ["location", "frame", "stacked_plot"],
     "text": [
         "text", "x", "y", "size", "color",
         "horizontal_align", "vertical_align",

--- a/quicklooks/_chart.py
+++ b/quicklooks/_chart.py
@@ -89,6 +89,20 @@ def _end_label_pad_points(chart: Chart) -> float:
     return max(4.0, 0.28 * chart.font_style.size.l)
 
 
+def _last_end_label_xy_index(x: Any, y: Any) -> Optional[int]:
+    """Last index where *x* and *y* are both defined and *y* is finite."""
+    y_arr = np.asarray(y, dtype=float)
+    n = int(y_arr.shape[0])
+    for i in range(n - 1, -1, -1):
+        if not np.isfinite(y_arr[i]):
+            continue
+        xi = x.iloc[i] if isinstance(x, pd.Series) else x[i]
+        if pd.isna(xi):
+            continue
+        return i
+    return None
+
+
 def _end_label_offset_from_anchor(
     chart: Chart,
     *,

--- a/quicklooks/_chart.py
+++ b/quicklooks/_chart.py
@@ -59,6 +59,89 @@ class Chart:
         self.yrange = yrange
         self.xaxis_type = xaxis_type
         self.xlabel = xlabel
+        # (label, "pos"|"neg") per ql.area / ql.stacked_bar call with a label;
+        # used by ql.legend(..., stacked_plot=True) for diverging charts.
+        self._stacked_legend_entries: list[tuple[str, str]] = []
+
+
+def _record_stacked_legend_label(
+    chart: Chart,
+    label: str,
+    *,
+    has_pos: bool,
+    has_neg: bool,
+) -> None:
+    """Append legend metadata for stacked area/bar (see ql.legend stacked_plot)."""
+    if not label:
+        return
+    if has_pos and not has_neg:
+        side = "pos"
+    elif has_neg and not has_pos:
+        side = "neg"
+    else:
+        # Mixed-sign series: label is attached to the positive artist first.
+        side = "pos"
+    chart._stacked_legend_entries.append((label, side))
+
+
+def _end_label_pad_points(chart: Chart) -> float:
+    """Horizontal/vertical gap from anchor for end-style labels (typography-based)."""
+    return max(4.0, 0.28 * chart.font_style.size.l)
+
+
+def _end_label_offset_from_anchor(
+    chart: Chart,
+    *,
+    x_anchor: Any,
+    y_anchor: Any,
+    text: str,
+    color: Any,
+    zorder: int,
+    dx_pts: float,
+    dy_pts: float,
+    horizontalalignment: str = "left",
+    verticalalignment: str = "center",
+) -> None:
+    """Draw *text* using ``annotate`` + ``offset points`` from data (*x_anchor*, *y_anchor*)."""
+    chart.ax.annotate(
+        text,
+        xy=(x_anchor, y_anchor),
+        xytext=(dx_pts, dy_pts),
+        textcoords="offset points",
+        xycoords="data",
+        horizontalalignment=horizontalalignment,
+        verticalalignment=verticalalignment,
+        color=color,
+        fontproperties=chart.font_style.label,
+        zorder=zorder,
+    )
+
+
+def _end_label_right_of_anchor(
+    chart: Chart,
+    *,
+    x_anchor: Any,
+    y: Any,
+    text: str,
+    color: Any,
+    zorder: int,
+    horizontalalignment: str = "left",
+    verticalalignment: str = "center",
+) -> None:
+    """End label to the right of the anchor (``dx`` = pad pts, ``dy`` = 0)."""
+    p = _end_label_pad_points(chart)
+    _end_label_offset_from_anchor(
+        chart,
+        x_anchor=x_anchor,
+        y_anchor=y,
+        text=text,
+        color=color,
+        zorder=zorder,
+        dx_pts=p,
+        dy_pts=0.0,
+        horizontalalignment=horizontalalignment,
+        verticalalignment=verticalalignment,
+    )
 
 
 def chart(

--- a/quicklooks/_legend.py
+++ b/quicklooks/_legend.py
@@ -2,12 +2,38 @@
 
 from __future__ import annotations
 
-from typing import Any, Union
-
 from ._chart import Chart
 from ._config import VALID_LEGEND_LOCATIONS
 from ._types import LegendResult
-from ._validators import validate_chart, validate_option
+from ._validators import validate_bool, validate_chart, validate_option
+
+
+def _ordered_stacked_legend_handles(
+    chart: Chart,
+    handles: list,
+    labels: list,
+) -> tuple[list, list]:
+    """Reorder legend rows for stacked plots; supports diverging pos/neg stacks."""
+    entries = getattr(chart, "_stacked_legend_entries", None) or []
+    if not entries:
+        return handles[::-1], labels[::-1]
+    label_to_handle = dict(zip(labels, handles))
+    pos_labels = [lab for lab, side in entries if side == "pos"]
+    neg_labels = [lab for lab, side in entries if side == "neg"]
+    # Above zero: reverse call order (first drawn = bottom of stack).
+    # Below zero: keep call order (first drawn = closest to axis = top of neg stack).
+    ordered_labels = pos_labels[::-1] + neg_labels
+    ordered_handles = [
+        label_to_handle[lab] for lab in ordered_labels if lab in label_to_handle
+    ]
+    used = set(ordered_labels)
+    extra_h: list = []
+    extra_l: list = []
+    for h, lab in zip(handles, labels):
+        if lab not in used:
+            extra_h.append(h)
+            extra_l.append(lab)
+    return ordered_handles + extra_h, ordered_labels + extra_l
 
 
 def legend(
@@ -15,6 +41,7 @@ def legend(
     *,
     location: str = "best",
     frame: bool = False,
+    stacked_plot: bool = False,
 ) -> LegendResult:
     """Add a legend to a chart.
 
@@ -22,6 +49,11 @@ def legend(
         chart: Chart object created by ``ql.chart()``.
         location: Legend placement.
         frame: If ``True``, draw a border around the legend.
+        stacked_plot: If ``True``, order legend rows to match stacked layers.
+            For diverging charts (values above and below zero), positive
+            series appear first (top to bottom: top-of-stack to bottom), then
+            negative series (same). Other legend entries (e.g. ``ql.refline()``
+            with a label) follow.
 
     Returns:
         A ``LegendResult`` with a reference to the matplotlib legend.
@@ -31,6 +63,7 @@ def legend(
     # -- validation ------------------------------------------------------------
     validate_chart(chart, _fn)
     validate_option(location, VALID_LEGEND_LOCATIONS, "location", _fn)
+    validate_bool(stacked_plot, "stacked_plot", _fn)
 
     # -- common kwargs ---------------------------------------------------------
     common = dict(
@@ -44,19 +77,26 @@ def legend(
     )
 
     # -- create legend ---------------------------------------------------------
+    if stacked_plot:
+        handles, labels = chart.ax.get_legend_handles_labels()
+        handles, labels = _ordered_stacked_legend_handles(chart, handles, labels)
+        legend_kw = dict(handles=handles, labels=labels, **common)
+    else:
+        legend_kw = common
+
     if location == "outside right":
         legend_artist = chart.ax.legend(
-            loc="center left", bbox_to_anchor=(1.025, 0.5), **common,
+            loc="center left", bbox_to_anchor=(1.025, 0.5), **legend_kw,
         )
     elif location == "below":
         offset = -0.2 if chart.xlabel else -0.1
         ncol = 3 if chart.size == "half_slide" else 4
         legend_artist = chart.ax.legend(
             loc="upper center", bbox_to_anchor=(0.5, offset),
-            ncol=ncol, **common,
+            ncol=ncol, **legend_kw,
         )
     else:
-        legend_artist = chart.ax.legend(loc=location, **common)
+        legend_artist = chart.ax.legend(loc=location, **legend_kw)
 
     # -- text color ------------------------------------------------------------
     for text_obj in legend_artist.get_texts():

--- a/quicklooks/plots/_area.py
+++ b/quicklooks/plots/_area.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
 from typing import Any, Union
 
 import numpy as np
 import pandas as pd  # type: ignore
 
-from .._chart import Chart
+from .._chart import Chart, _end_label_right_of_anchor, _record_stacked_legend_label
 from .._colors import resolve_color
 from .._types import AreaResult
 from .._validators import (
@@ -86,6 +85,9 @@ def area(
 
     has_pos = np.any(y_pos > 0)
     has_neg = np.any(y_neg < 0)
+    _record_stacked_legend_label(
+        chart, label, has_pos=has_pos, has_neg=has_neg,
+    )
 
     # -- resolve color ---------------------------------------------------------
     fill_c, line_c, _ = resolve_color(chart.color_library, color, _fn)
@@ -144,17 +146,11 @@ def area(
         else:
             y_mid = (neg_bottom[-1] + neg_top[-1]) / 2
 
-        if chart.xaxis_type == "timeseries":
-            x_loc = x_end + timedelta(days=chart.xrange * 0.01)
-        else:
-            x_loc = x_end + chart.xrange * 0.01
-
-        chart.ax.text(
-            x_loc, y_mid, label,
-            fontproperties=chart.font_style.label,
-            horizontalalignment="left",
-            verticalalignment="center",
-            size=chart.font_style.size.l,
+        _end_label_right_of_anchor(
+            chart,
+            x_anchor=x_end,
+            y=y_mid,
+            text=label,
             color=line_c,
             zorder=layer_order + 3,
         )

--- a/quicklooks/plots/_area.py
+++ b/quicklooks/plots/_area.py
@@ -7,7 +7,12 @@ from typing import Any, Union
 import numpy as np
 import pandas as pd  # type: ignore
 
-from .._chart import Chart, _end_label_right_of_anchor, _record_stacked_legend_label
+from .._chart import (
+    Chart,
+    _end_label_right_of_anchor,
+    _last_end_label_xy_index,
+    _record_stacked_legend_label,
+)
 from .._colors import resolve_color
 from .._types import AreaResult
 from .._validators import (
@@ -43,7 +48,8 @@ def area(
         chart: Chart object created by ``ql.chart()``.
         x: 1D array of x-axis values.
         y: 1D array of y values for this band (the height of this band, not
-            the cumulative total).
+            the cumulative total). Non-finite entries add no stacked height and
+            are left out of the filled polygon so bands do not extend past real data.
         color: Color name from the chart's color library, or a 3-tuple.
         linewidth: Width of the top-edge line.
         opacity: Alpha transparency for the filled area (0 to 1).
@@ -64,16 +70,19 @@ def area(
     validate_1d_array(y, "y", _fn)
     validate_matching_shapes(x, y, "x", "y", _fn)
 
-    y_arr = np.nan_to_num(np.asarray(y, dtype=float))
+    y_raw = np.asarray(y, dtype=float)
+    # Stacking: missing values contribute no height (same as zero). Drawing uses
+    # NaN below so fill_between does not span across trailing gaps.
+    y_stk = np.where(np.isfinite(y_raw), y_raw, 0.0)
 
     # -- diverging baselines (lazily initialised on first call) ----------------
     if not hasattr(chart, "_area_baseline_pos"):
-        chart._area_baseline_pos = np.zeros(len(y_arr))
+        chart._area_baseline_pos = np.zeros(len(y_stk))
     if not hasattr(chart, "_area_baseline_neg"):
-        chart._area_baseline_neg = np.zeros(len(y_arr))
+        chart._area_baseline_neg = np.zeros(len(y_stk))
 
-    y_pos = np.maximum(y_arr, 0)
-    y_neg = np.minimum(y_arr, 0)
+    y_pos = np.maximum(y_stk, 0)
+    y_neg = np.minimum(y_stk, 0)
 
     pos_bottom = chart._area_baseline_pos.copy()
     neg_bottom = chart._area_baseline_neg.copy()
@@ -83,8 +92,9 @@ def area(
     chart._area_baseline_pos = pos_top.copy()
     chart._area_baseline_neg = neg_top.copy()
 
-    has_pos = np.any(y_pos > 0)
-    has_neg = np.any(y_neg < 0)
+    valid = np.isfinite(y_raw)
+    has_pos = np.any(valid & (y_raw > 0))
+    has_neg = np.any(valid & (y_raw < 0))
     _record_stacked_legend_label(
         chart, label, has_pos=has_pos, has_neg=has_neg,
     )
@@ -93,16 +103,21 @@ def area(
     fill_c, line_c, _ = resolve_color(chart.color_library, color, _fn)
 
     # -- filled areas ----------------------------------------------------------
+    pos_bottom_d = np.where(valid, pos_bottom, np.nan)
+    pos_top_d = np.where(valid, pos_top, np.nan)
+    neg_bottom_d = np.where(valid, neg_bottom, np.nan)
+    neg_top_d = np.where(valid, neg_top, np.nan)
+
     fill_artist = None
     if has_pos:
         fill_artist = chart.ax.fill_between(
-            x, pos_bottom, pos_top,
+            x, pos_bottom_d, pos_top_d,
             color=fill_c, alpha=opacity, label=None,
             zorder=layer_order + 2,
         )
     if has_neg:
         fill_neg = chart.ax.fill_between(
-            x, neg_top, neg_bottom,
+            x, neg_top_d, neg_bottom_d,
             color=fill_c, alpha=opacity, label=None,
             zorder=layer_order + 2,
         )
@@ -116,7 +131,7 @@ def area(
     _label = label  # consume label on first line drawn to avoid double entries
 
     if has_pos:
-        pos_line = np.where(y_arr > 0, pos_top, np.nan)
+        pos_line = np.where(valid & (y_stk > 0), pos_top, np.nan)
         line_artist = chart.ax.plot(
             x, pos_line,
             linewidth=linewidth, color=line_c,
@@ -126,7 +141,7 @@ def area(
         _label = None
 
     if has_neg:
-        neg_line = np.where(y_arr < 0, neg_top, np.nan)
+        neg_line = np.where(valid & (y_stk < 0), neg_top, np.nan)
         neg_line_artist = chart.ax.plot(
             x, neg_line,
             linewidth=linewidth, color=line_c,
@@ -138,21 +153,20 @@ def area(
 
     # -- end label -------------------------------------------------------------
     if end_label and label:
-        x_end = x.iloc[-1] if isinstance(x, pd.Series) else np.asarray(x)[-1]
-
-        last_y = y_arr[-1]
-        if last_y >= 0:
-            y_mid = (pos_bottom[-1] + pos_top[-1]) / 2
-        else:
-            y_mid = (neg_bottom[-1] + neg_top[-1]) / 2
-
-        _end_label_right_of_anchor(
-            chart,
-            x_anchor=x_end,
-            y=y_mid,
-            text=label,
-            color=line_c,
-            zorder=layer_order + 3,
-        )
+        idx = _last_end_label_xy_index(x, y_raw)
+        if idx is not None:
+            x_end = x.iloc[idx] if isinstance(x, pd.Series) else np.asarray(x)[idx]
+            if y_raw[idx] >= 0:
+                y_mid = (pos_bottom[idx] + pos_top[idx]) / 2
+            else:
+                y_mid = (neg_bottom[idx] + neg_top[idx]) / 2
+            _end_label_right_of_anchor(
+                chart,
+                x_anchor=x_end,
+                y=y_mid,
+                text=label,
+                color=line_c,
+                zorder=layer_order + 3,
+            )
 
     return AreaResult(fill=fill_artist, line=line_artist)

--- a/quicklooks/plots/_line.py
+++ b/quicklooks/plots/_line.py
@@ -7,7 +7,7 @@ from typing import Any, Optional, Union
 import numpy as np
 import pandas as pd  # type: ignore
 
-from .._chart import Chart, _end_label_right_of_anchor
+from .._chart import Chart, _end_label_right_of_anchor, _last_end_label_xy_index
 from .._colors import resolve_color
 from .._config import VALID_LINESTYLES, VALID_MARKERS
 from .._styling import get_marker_size
@@ -107,16 +107,18 @@ def line(
 
     # -- end label -------------------------------------------------------------
     if end_label and label:
-        x_end = x.iloc[-1] if isinstance(x, pd.Series) else x[-1]
-        y_end = y.iloc[-1] if isinstance(y, pd.Series) else y[-1]
-        _end_label_right_of_anchor(
-            chart,
-            x_anchor=x_end,
-            y=y_end,
-            text=label,
-            color=line_c,
-            zorder=layer_order + 2,
-        )
+        idx = _last_end_label_xy_index(x, y)
+        if idx is not None:
+            x_end = x.iloc[idx] if isinstance(x, pd.Series) else x[idx]
+            y_end = y.iloc[idx] if isinstance(y, pd.Series) else y[idx]
+            _end_label_right_of_anchor(
+                chart,
+                x_anchor=x_end,
+                y=y_end,
+                text=label,
+                color=line_c,
+                zorder=layer_order + 2,
+            )
 
     return LineResult(
         line=line_artist,

--- a/quicklooks/plots/_line.py
+++ b/quicklooks/plots/_line.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
 from typing import Any, Optional, Union
 
 import numpy as np
 import pandas as pd  # type: ignore
 
-from .._chart import Chart
+from .._chart import Chart, _end_label_right_of_anchor
 from .._colors import resolve_color
 from .._config import VALID_LINESTYLES, VALID_MARKERS
 from .._styling import get_marker_size
@@ -110,18 +109,11 @@ def line(
     if end_label and label:
         x_end = x.iloc[-1] if isinstance(x, pd.Series) else x[-1]
         y_end = y.iloc[-1] if isinstance(y, pd.Series) else y[-1]
-
-        if chart.xaxis_type == "timeseries":
-            x_loc = x_end + timedelta(days=chart.xrange * 0.01)
-        else:
-            x_loc = x_end + chart.xrange * 0.01
-
-        chart.ax.text(
-            x_loc, y_end, label,
-            fontproperties=chart.font_style.label,
-            horizontalalignment="left",
-            verticalalignment="center",
-            size=chart.font_style.size.l,
+        _end_label_right_of_anchor(
+            chart,
+            x_anchor=x_end,
+            y=y_end,
+            text=label,
             color=line_c,
             zorder=layer_order + 2,
         )

--- a/quicklooks/plots/_refline.py
+++ b/quicklooks/plots/_refline.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Any, Optional, Union
 
 import numpy as np
 import pandas as pd  # type: ignore
 
-from .._chart import Chart
+from .._chart import Chart, _end_label_offset_from_anchor, _end_label_pad_points, _end_label_right_of_anchor
 from .._colors import resolve_color
 from .._config import VALID_LINESTYLES, VALID_MARKERS, VALID_REFLINE_DIRECTIONS
 from .._styling import get_marker_size
@@ -111,37 +111,39 @@ def refline(
 
     # -- end label -------------------------------------------------------------
     if end_label and label:
-        yrange = chart.y_min_max[1] - chart.y_min_max[0]
-
         if direction == "horizontal":
-            if chart.xaxis_type == "timeseries":
-                x_loc = x[-1] + timedelta(days=chart.xrange * 0.01)
-            else:
-                x_loc = x[-1] + chart.xrange * 0.01
-            y_loc = location
-            ha, va = "left", "center"
+            _end_label_right_of_anchor(
+                chart,
+                x_anchor=x[-1],
+                y=location,
+                text=label,
+                color=line_c,
+                zorder=layer_order + 2,
+            )
 
         elif direction == "vertical":
-            x_loc = parsed_location
-            y_loc = chart.y_min_max[1] + yrange * 0.01
-            ha, va = "center", "bottom"
+            p = _end_label_pad_points(chart)
+            _end_label_offset_from_anchor(
+                chart,
+                x_anchor=parsed_location,
+                y_anchor=chart.y_min_max[1],
+                text=label,
+                color=line_c,
+                zorder=layer_order + 2,
+                dx_pts=0.0,
+                dy_pts=p,
+                horizontalalignment="center",
+                verticalalignment="bottom",
+            )
 
         else:  # diagonal_up / diagonal_down — label at the right end
-            if chart.xaxis_type == "timeseries":
-                x_loc = x[-1] + timedelta(days=chart.xrange * 0.01)
-            else:
-                x_loc = x[-1] + chart.xrange * 0.01
-            y_loc = y[-1]
-            ha, va = "left", "center"
-
-        chart.ax.text(
-            x_loc, y_loc, label,
-            fontproperties=chart.font_style.label,
-            horizontalalignment=ha,
-            verticalalignment=va,
-            size=chart.font_style.size.l,
-            color=line_c,
-            zorder=layer_order + 2,
-        )
+            _end_label_right_of_anchor(
+                chart,
+                x_anchor=x[-1],
+                y=y[-1],
+                text=label,
+                color=line_c,
+                zorder=layer_order + 2,
+            )
 
     return RefLineResult(line=line_artist)

--- a/quicklooks/plots/_stacked_bar.py
+++ b/quicklooks/plots/_stacked_bar.py
@@ -7,7 +7,7 @@ from typing import Any, Union
 import matplotlib.pyplot as plt  # type: ignore
 import numpy as np
 
-from .._chart import Chart
+from .._chart import Chart, _record_stacked_legend_label
 from .._colors import resolve_color
 from .._types import StackedBarResult
 from .._validators import (
@@ -88,6 +88,12 @@ def stacked_bar(
 
     pos_baseline = chart._sbar_baseline_pos.copy()
     neg_baseline = chart._sbar_baseline_neg.copy()
+
+    has_pos = np.any(y_pos > 0)
+    has_neg = np.any(y_neg < 0)
+    _record_stacked_legend_label(
+        chart, label, has_pos=has_pos, has_neg=has_neg,
+    )
 
     # -- resolve color ---------------------------------------------------------
     _, line_c, edge_c = resolve_color(chart.color_library, color, _fn)

--- a/quicklooks/skill/SKILL.md
+++ b/quicklooks/skill/SKILL.md
@@ -219,6 +219,7 @@ ql.dist(cs,
 ql.legend(cs,
     location="outside right",
     frame=False,
+    stacked_plot=False,  # True for ql.area / ql.stacked_bar charts — orders legend to match stack
 );
 ```
 

--- a/quicklooks/skill/SKILL.md
+++ b/quicklooks/skill/SKILL.md
@@ -46,6 +46,7 @@ cs = ql.chart(
     x_min_max=(0, 10),           # literal tuple only — no variables or expressions
                                  # TIMESERIES: use date strings ("YYYY-MM-DD", "YYYY-MM-DD")
                                  # NON-TIMESERIES: must be divisible by xtick_interval
+                                 # BAR PLOT: (-0.5, len(xlabels)-0.5)
     y_min_max=(0, 100),          # literal tuple only — no variables or expressions
                                  # based on SINGLE series max, NOT the sum across series
                                  # y_min_max[1] MUST be divisible by ytick_interval (no partial tick)
@@ -61,6 +62,7 @@ cs = ql.chart(
     xtick_labels="default",      # NON-TIMESERIES: "default"
                                  # TIMESERIES: "days" (<4 wks) | "weeks" (4 wks–2 mo) |
                                  #             "months" (2–15 mo) | "quarters" (9 mo–4 yr) | "years" (>4 yr)
+                                 # BAR PLOT: "default"
     ytick_labels="default",      # "default" | ">1k" → "1k" | ">100k" → "100k" | ">1M" → "1m" | percentages → "percents"
     horizontal_gridlines=False,
     vertical_gridlines=False,
@@ -165,7 +167,7 @@ for i, col in enumerate(df.columns):
 
 ```python
 ql.bar(cs,
-    xlabels=xlabels,    # any series — strings, dates, and numbers all work
+    xlabels=xlabels,    # any series — strings, dates, and numbers all work; these will overwrite the chart x labels
     y=y,
     color="blue",       # must be a valid name in the active color library — check reference.md
     yerror=None,

--- a/quicklooks/skill/reference.md
+++ b/quicklooks/skill/reference.md
@@ -156,6 +156,7 @@ Adds a legend to the chart.
 | chart | Chart | required | Chart object (positional) |
 | location | str | "best" | "best", "upper right", "upper left", "lower left", "lower right", "right", "center left", "center right", "lower center", "upper center", "center", "outside right", "below" |
 | frame | bool | False | Draw border around legend |
+| stacked_plot | bool | False | Order legend rows to match stacked layers (for ql.area / ql.stacked_bar) |
 
 ## ql.text()
 


### PR DESCRIPTION
## Summary

Improves end labels (typography-based placement), fixes stacked-area behavior when `y` has leading or trailing NaNs, adds optional legend ordering for stacked plots, and aligns the skill templates / cell linter with the new `ql.legend(..., stacked_plot=...)` parameter.

## End labels

- Replace data-space x-offsets (`xrange * 0.01` / `timedelta`) + `ax.text` with `annotate` using **offset points**, so spacing scales with font size and DPI (`_end_label_pad_points`, `_end_label_right_of_anchor`, `_end_label_offset_from_anchor` in `_chart.py`).
- **`ql.line`** and **`ql.area`**: anchor end labels at the **last finite** `(x, y)` via `_last_end_label_xy_index` so trailing NaNs (e.g. misaligned series or rolling warmup) do not break or hide labels.
- **`ql.refline`**: horizontal and diagonal use the same right-of-anchor helper; vertical uses a point offset above the top y-limit.

## Stacked areas and NaNs

- **`ql.area`**: use `y_raw` for “where is data valid” and `y_stk` (finite → value, else 0) for stacking. Mask draw arrays with `np.nan` where `y` is non-finite so `fill_between` does not span bogus wedges across leading/trailing gaps. Edge lines use `valid & (y_stk > 0)` / `< 0` consistently.

## Legend

- **`ql.legend(..., stacked_plot=False)`**: when `True`, reorder handles/labels using `_stacked_legend_entries` recorded from **`ql.area`** and **`ql.stacked_bar`** (pos vs neg side for diverging stacks). Extra artists (e.g. refline) are appended after stacked entries.
- **`_cell_linter`**: `legend` expected params include `stacked_plot`.

## Docs / skills

- **`SKILL.md`**: `ql.legend` template includes `stacked_plot=False` with a short comment (required for `validate_cell`); small bar-plot chart hints unchanged from prior edits.
- **`reference.md`**: document `stacked_plot` on `ql.legend`.
- Cursor skill copies kept in sync with package skill files.